### PR TITLE
Fix onPageChanged handler not firing

### DIFF
--- a/pdfviewer/pdfJsViewer/pdfJsViewer.js
+++ b/pdfviewer/pdfJsViewer/pdfJsViewer.js
@@ -3,7 +3,8 @@ angular.module('pdfviewerPdfJsViewer', ['servoy']).directive('pdfviewerPdfJsView
         restrict: 'E',
         scope: {
             model: '=svyModel',
-            api: "=svyApi"
+            api: "=svyApi",
+            handlers: "=svyHandlers"
         },
         link: function($scope, $element, $attrs) {
             $scope.iframeURL = '';
@@ -30,7 +31,12 @@ angular.module('pdfviewerPdfJsViewer', ['servoy']).directive('pdfviewerPdfJsView
                             else disableTooltips();
                             fillOutFormFields();
                             hideFieldControls();
-                        })
+                        });
+                        if ($scope.handlers.onPageChanged) {
+                            viewer.eventBus.on("pagechanging", (evt) => {
+                                $scope.handlers.onPageChanged(evt.pageNumber, evt.previous);
+                            });
+                        }
                     });
                 });
             }


### PR DESCRIPTION
This pull requests fixes an issue with the onPageChanged event not firing.

## Summary

- The `onPageChanged` handler was defined in `pdfJsViewer.spec` but never wired up in the AngularJS directive (`pdfJsViewer.js`), so the event never fired.
- Added `handlers: "=svyHandlers"` to the directive's scope bindings to expose handler functions.
- Registered a `pagechanging` listener on the PDF.js `eventBus` inside `renderFinished()`, calling the handler directly without `$scope.$apply()` to avoid digest cycle collisions that prevented the event from firing during upward page navigation.