### PR TITLE
Fix cross-origin SecurityError in addCustomCSS()

### DIFF
--- a/pdfviewer/pdfJsViewer/pdfJsViewer.js
+++ b/pdfviewer/pdfJsViewer/pdfJsViewer.js
@@ -97,7 +97,7 @@ angular.module('pdfviewerPdfJsViewer', ['servoy']).directive('pdfviewerPdfJsView
                             link.href = serverUrl + '/' + $scope.model.styleSheet;
                             link.rel = "stylesheet";
                             link.type = "text/css";
-                            frames[0].document.head.appendChild(link);
+                            iframe.contentWindow.document.head.appendChild(link);
                         });
                     })
                 }


### PR DESCRIPTION
This pull request resolves the below cross-origin `SecurityError` thrown by `addCustomCSS()` in `pdfJsViewer.js` when attempting to inject a custom stylesheet into the PDF viewer iframe.

```
ERROR org.sablo.BrowserConsole - Uncaught SecurityError: Failed to read a named property 'document' from 'Window': Blocked a frame with origin "http://localhost:8183" from accessing a cross-origin frame.
http://localhost:8183/pdfviewer/pdfJsViewer/pdfJsViewer.js:100:39
SecurityError: Failed to read a named property 'document' from 'Window': Blocked a frame with origin "http://localhost:8183" from accessing a cross-origin frame.
```

## Summary
- addCustomCSS()` used `frames[0].document.head` to append the custom stylesheet link, which triggers a `SecurityError` due to cross-origin frame access restrictions.
- Replaced with `iframe.contentWindow.document.head`, using the local `iframe` reference that is already in scope from the line above.